### PR TITLE
Replace Expansion Panel with FAB, New note from FAB overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "husky": "^1.3.1",
     "lint-staged": "^8.1.5",
     "prop-types": "^15.7.2",
+    "qrcode.react": "^0.9.3",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",

--- a/src/actions/noteDialog.js
+++ b/src/actions/noteDialog.js
@@ -4,6 +4,7 @@
 export const SHOW_NOTE_DIALOG = "SHOW_NOTE_DIALOG";
 export const HIDE_NOTE_DIALOG = "HIDE_NOTE_DIALOG";
 export const SAVE_NOTE_DIALOG_CONTENT = "SAVE_NOTE_DIALOG_CONTENT";
+export const ADD_NOTE = "ADD_NOTE";
 /**
  * Action Creators
  */
@@ -14,5 +15,9 @@ export const saveDialogContent = () => (dispatch, getState) => {
   const {
     noteForm: { note }
   } = getState();
-  dispatch({ type: SAVE_NOTE_DIALOG_CONTENT, payload: note });
+  // TODO: Handle validation
+  if (note !== undefined) {
+    if (note.uuid === undefined) dispatch({ type: ADD_NOTE, payload: note });
+    else dispatch({ type: SAVE_NOTE_DIALOG_CONTENT, payload: note });
+  }
 };

--- a/src/actions/workspacePage.js
+++ b/src/actions/workspacePage.js
@@ -7,6 +7,9 @@ export const HIDE_DRAWER = "HIDE_DRAWER";
 export const FAB_CHECKED = "FAB_CHECKED";
 export const FAB_HIDDEN = "FAB_HIDDEN";
 
+export const SHOW_CREATE_USER_DIALOG = "SHOW_CREATE_USER_DIALOG";
+export const HIDE_CREATE_USER_DIALOG = "HIDE_CREATE_USER_DIALOG";
+
 /**
  * Action Creators
  */
@@ -15,3 +18,8 @@ export const hideDrawer = () => dispatch => dispatch({ type: HIDE_DRAWER });
 
 export const fabChecked = () => dispatch => dispatch({ type: FAB_CHECKED });
 export const fabHidden = () => dispatch => dispatch({ type: FAB_HIDDEN });
+
+export const showCreateUserDialog = () => dispatch =>
+  dispatch({ type: SHOW_CREATE_USER_DIALOG });
+export const hideCreateUserDialog = () => dispatch =>
+  dispatch({ type: HIDE_CREATE_USER_DIALOG });

--- a/src/actions/workspacePage.js
+++ b/src/actions/workspacePage.js
@@ -4,8 +4,14 @@
 export const SHOW_DRAWER = "SHOW_DRAWER";
 export const HIDE_DRAWER = "HIDE_DRAWER";
 
+export const FAB_CHECKED = "FAB_CHECKED";
+export const FAB_HIDDEN = "FAB_HIDDEN";
+
 /**
  * Action Creators
  */
 export const showDrawer = () => dispatch => dispatch({ type: SHOW_DRAWER });
 export const hideDrawer = () => dispatch => dispatch({ type: HIDE_DRAWER });
+
+export const fabChecked = () => dispatch => dispatch({ type: FAB_CHECKED });
+export const fabHidden = () => dispatch => dispatch({ type: FAB_HIDDEN });

--- a/src/components/AddUserDialog/AddUserDialog.jsx
+++ b/src/components/AddUserDialog/AddUserDialog.jsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { connect } from "react-redux";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Slide,
+  Typography
+} from "@material-ui/core";
+import { withStyles } from "@material-ui/core/styles";
+import PropTypes from "prop-types";
+import QRCode from "qrcode.react";
+import { hideCreateUserDialog } from "../../actions/workspacePage";
+
+function Transition(props) {
+  return <Slide direction="up" {...props} />;
+}
+
+const styles = theme => ({
+  text: {
+    padding: theme.spacing.unit * 1.5
+  },
+  qrcode: {
+    padding: theme.spacing.unit * 1.5
+  }
+});
+
+const baseUrl = "https://puffnote.github.io/";
+
+function AddUserDialog(props) {
+  const {
+    showCreateUserDialog,
+    hideCreateUserDialog: hideUserDialog,
+    theme,
+    classes,
+    roomId
+  } = props;
+
+  const linkText = {
+    color: theme.palette.secondary.dark,
+    backgroundColor: theme.palette.background.default
+  };
+
+  return (
+    <div>
+      <Dialog
+        open={showCreateUserDialog}
+        onClose={() => hideUserDialog()}
+        TransitionComponent={Transition}
+        aria-labelledby="form-dialog-title"
+      >
+        <DialogTitle id="form-dialog-title">Invite User</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" className={classes.text}>
+            Use this unique link to invite user to workspace.
+          </Typography>
+          <Typography variant="body2" style={linkText} className={classes.text}>
+            {baseUrl}
+            {roomId}
+          </Typography>
+          <QRCode className={classes.qrcode} value={baseUrl + roomId} />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => hideUserDialog()}
+            variant="contained"
+            color="secondary"
+          >
+            Back
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+AddUserDialog.defaultProps = {
+  showCreateUserDialog: false
+};
+
+AddUserDialog.propTypes = {
+  showCreateUserDialog: PropTypes.bool,
+  hideCreateUserDialog: PropTypes.func.isRequired,
+  roomId: PropTypes.string.isRequired,
+  classes: PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired
+};
+
+const mapStateToProps = ({
+  workspacePage: { showCreateUserDialog, roomId }
+}) => ({
+  showCreateUserDialog,
+  roomId
+});
+
+const mapDispatchToProps = {
+  hideCreateUserDialog
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withStyles(styles, { withTheme: true })(AddUserDialog));

--- a/src/components/CreateWorkspaceDialog/CreateWorkspaceDialog.jsx
+++ b/src/components/CreateWorkspaceDialog/CreateWorkspaceDialog.jsx
@@ -41,6 +41,7 @@ const CreateWorkspaceDialog = ({
           id="room_name"
           label="Workspace Name"
           type="text"
+          variant="outlined"
           fullWidth
         />
         <TextField
@@ -48,6 +49,7 @@ const CreateWorkspaceDialog = ({
           id="user_name"
           label="User Full Name"
           type="text"
+          variant="outlined"
           fullWidth
         />
       </DialogContent>

--- a/src/components/LandingPage/LandingPage.jsx
+++ b/src/components/LandingPage/LandingPage.jsx
@@ -30,7 +30,8 @@ const styles = theme => ({
     width: "100%"
   },
   mainContent: {
-    width: "100%"
+    width: "100%",
+    marginBottom: "10%"
   },
   subMainContent: {
     display: "flex",
@@ -77,7 +78,7 @@ const styles = theme => ({
     width: 150
   },
   footerText: {
-    color: theme.palette.secondary.main
+    color: theme.palette.common.black
   }
 });
 

--- a/src/components/NoteDialog/NoteDialog.jsx
+++ b/src/components/NoteDialog/NoteDialog.jsx
@@ -7,7 +7,7 @@ import {
   DialogContent,
   Slide
 } from "@material-ui/core";
-import { withTheme } from "@material-ui/core/styles";
+import { withStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
 import { hideNoteDialog, saveDialogContent } from "../../actions/noteDialog";
 import NoteForm from "../NoteForm/NoteForm";
@@ -16,7 +16,13 @@ function Transition(props) {
   return <Slide direction="up" {...props} />;
 }
 
-const NoteDialog = ({ open, hide, save }) => (
+const styles = theme => ({
+  dialog: {
+    padding: theme.spacing.unit * 1
+  }
+});
+
+const NoteDialog = ({ classes, open, hide, save }) => (
   <div>
     <Dialog
       fullWidth
@@ -25,7 +31,7 @@ const NoteDialog = ({ open, hide, save }) => (
       TransitionComponent={Transition}
       onClose={() => hide()}
     >
-      <DialogContent>
+      <DialogContent className={classes.dialog}>
         <NoteForm />
       </DialogContent>
 
@@ -48,7 +54,9 @@ NoteDialog.defaultProps = {
 NoteDialog.propTypes = {
   open: PropTypes.bool,
   hide: PropTypes.func.isRequired,
-  save: PropTypes.func.isRequired
+  save: PropTypes.func.isRequired,
+  classes: PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired
 };
 
 const mapStateToProps = ({ noteDialog: { open } }) => ({
@@ -63,4 +71,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(withTheme({})(NoteDialog));
+)(withStyles(styles, { withTheme: true })(NoteDialog));

--- a/src/components/NoteForm/NoteForm.jsx
+++ b/src/components/NoteForm/NoteForm.jsx
@@ -22,7 +22,7 @@ const NoteForm = ({ classes, note, title, content }) => {
       <Typography variant="h5" color="inherit">
         New Note
       </Typography>
-      <form className={classes.form} noValidate autoComplete="off">
+      <form className={classes.form} noValidate={false} autoComplete="off">
         <TextField
           id="standard-title"
           label="Title"
@@ -35,7 +35,10 @@ const NoteForm = ({ classes, note, title, content }) => {
         <TextField
           id="standard-multiline-content"
           multiline
+          rows="4"
           label="Note"
+          autoFocus
+          required
           maxheight="50%"
           variant="outlined"
           margin="normal"

--- a/src/components/NoteForm/NoteForm.jsx
+++ b/src/components/NoteForm/NoteForm.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TextField } from "@material-ui/core";
+import { TextField, Typography } from "@material-ui/core";
 import { withStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
@@ -9,16 +9,20 @@ import { setTitle, setContent } from "../../actions/noteForm";
 const styles = theme => ({
   root: {
     display: "flex",
+    flexDirection: "column",
     flexWrap: "wrap",
     backgroundColor: theme.palette.background.paper,
-    width: "100%"
+    padding: theme.spacing.unit * 1.5
   }
 });
 
 const NoteForm = ({ classes, note, title, content }) => {
   return (
     <div className={classes.root}>
-      <form noValidate autoComplete="off">
+      <Typography variant="h5" color="inherit">
+        New Note
+      </Typography>
+      <form className={classes.form} noValidate autoComplete="off">
         <TextField
           id="standard-title"
           label="Title"

--- a/src/components/WorkspaceCard/WorkspaceCard.jsx
+++ b/src/components/WorkspaceCard/WorkspaceCard.jsx
@@ -10,7 +10,7 @@ import {
   IconButton,
   Grid
 } from "@material-ui/core";
-import FavoriteIcon from "@material-ui/icons/Favorite";
+import BookmarkIcon from "@material-ui/icons/Bookmark";
 import DeleteIcon from "@material-ui/icons/Delete";
 import EditIcon from "@material-ui/icons/Edit";
 import { withStyles } from "@material-ui/core/styles";
@@ -53,7 +53,7 @@ const WorkspaceCard = ({ classes, edit, uuid, avatar, title, content }) => {
               {avatar}
             </Avatar>
             <IconButton>
-              <FavoriteIcon />
+              <BookmarkIcon />
             </IconButton>
           </Grid>
           <Typography gutterBottom variant="h5" component="h2">

--- a/src/components/WorkspacePage/WorkspacePage.jsx
+++ b/src/components/WorkspacePage/WorkspacePage.jsx
@@ -15,15 +15,14 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Fab,
-  Paper,
-  Slide
+  Fab
 } from "@material-ui/core";
 import MenuIcon from "@material-ui/icons/Menu";
 import ChevronLeftIcon from "@material-ui/icons/ChevronLeft";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
-import FavoriteIcon from "@material-ui/icons/Favorite";
+import BookmarkIcon from "@material-ui/icons/Bookmark";
 import PersonIcon from "@material-ui/icons/Person";
+import PersonAddIcon from "@material-ui/icons/PersonAdd";
 import SettingsIcon from "@material-ui/icons/Settings";
 import AppsIcon from "@material-ui/icons/Apps";
 import AddIcon from "@material-ui/icons/Add";
@@ -32,11 +31,12 @@ import {
   showDrawer,
   hideDrawer,
   fabChecked,
-  fabHidden
+  fabHidden,
+  showCreateUserDialog
 } from "../../actions/workspacePage";
-import NoteForm from "../NoteForm/NoteForm";
 import NoteDialog from "../NoteDialog/NoteDialog";
 import { editNote } from "../../actions/workspaceCard";
+import AddUserDialog from "../AddUserDialog/AddUserDialog";
 
 const drawerWidth = 240;
 
@@ -63,8 +63,13 @@ const styles = theme => ({
     })
   },
   menuButton: {
-    marginLeft: 12,
-    marginRight: 36
+    marginLeft: theme.spacing.unit * 0.5,
+    marginRight: theme.spacing.unit * 4.5
+  },
+  addUserButton: {
+    alignSelf: "center",
+    marginLeft: "auto",
+    marginRight: theme.spacing.unit * 1.5
   },
   hide: {
     display: "none"
@@ -122,29 +127,24 @@ const styles = theme => ({
   },
   fabExtendedIcon: {
     marginRight: theme.spacing.unit
-  },
-  newNote: {
-    position: "fixed",
-    top: "auto",
-    left: "auto",
-    right: "12.5%",
-    bottom: "12.5%",
-    width: "75%",
-    height: "75%",
-    boxShadow: "0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23)",
-    zIndex: theme.zIndex.drawer + 2,
-    padding: theme.spacing.unit * 2
-  },
-  newNotePaper: {}
+  }
 });
 
 const users = ["Alex", "Price", "John", "Jim"];
-const noteCategories = ["Favorite Notes", "All Notes"];
+const noteCategories = ["Bookmarked Notes", "All Notes"];
 
 function WorkspacePage(props) {
-  const { classes, theme, drawerOpen, fabClicked, newNote } = props;
+  const {
+    classes,
+    theme,
+    drawerOpen,
+    showCreateUserDialog: showUserDialog
+  } = props;
   const colorWhite = {
     color: theme.palette.primary.contrastText
+  };
+  const colorSecondary = {
+    color: theme.palette.secondary.main
   };
   return (
     <div className={classes.page}>
@@ -198,12 +198,16 @@ function WorkspacePage(props) {
               )}
             </IconButton>
           </div>
-          <Divider />
+          <Divider light />
           <List>
             {noteCategories.map((text, index) => (
               <ListItem button key={text}>
                 <ListItemIcon style={colorWhite}>
-                  {index % 2 === 0 ? <FavoriteIcon /> : <AppsIcon />}
+                  {index % 2 === 0 ? (
+                    <BookmarkIcon style={colorSecondary} />
+                  ) : (
+                    <AppsIcon />
+                  )}
                 </ListItemIcon>
                 <ListItemText
                   primary={
@@ -215,8 +219,23 @@ function WorkspacePage(props) {
               </ListItem>
             ))}
           </List>
-          <Divider />
+          <Divider light />
           <List>
+            <ListItem onClick={() => showUserDialog()} button key="Settings">
+              <ListItemIcon
+                onClick={() => showUserDialog()}
+                style={colorSecondary}
+              >
+                <PersonAddIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary={
+                  <Typography variant="body1" style={colorWhite}>
+                    Add User
+                  </Typography>
+                }
+              />
+            </ListItem>
             {users.map(text => (
               <ListItem button key={text}>
                 <ListItemIcon style={colorWhite}>
@@ -232,9 +251,9 @@ function WorkspacePage(props) {
               </ListItem>
             ))}
           </List>
-          <Divider />
+          <Divider light />
           <ListItem button key="Settings">
-            <ListItemIcon style={colorWhite}>
+            <ListItemIcon style={colorSecondary}>
               <SettingsIcon />
             </ListItemIcon>
             <ListItemText
@@ -264,6 +283,7 @@ function WorkspacePage(props) {
         </Fab>
       </div>
       <NoteDialog />
+      <AddUserDialog />
     </div>
   );
 }
@@ -274,6 +294,7 @@ WorkspacePage.propTypes = {
   fabChecked: PropTypes.func.isRequired,
   fabHidden: PropTypes.func.isRequired,
   newNote: PropTypes.func.isRequired,
+  showCreateUserDialog: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
   theme: PropTypes.object.isRequired,
   drawerOpen: PropTypes.bool.isRequired,
@@ -290,7 +311,8 @@ const mapDispatchToProps = {
   hideDrawer,
   fabChecked,
   fabHidden,
-  newNote: editNote
+  newNote: editNote,
+  showCreateUserDialog
 };
 
 export default connect(

--- a/src/components/WorkspacePage/WorkspacePage.jsx
+++ b/src/components/WorkspacePage/WorkspacePage.jsx
@@ -79,7 +79,8 @@ const styles = theme => ({
     transition: theme.transitions.create("width", {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen
-    })
+    }),
+    backgroundColor: theme.palette.primary.main
   },
   drawerClose: {
     transition: theme.transitions.create("width", {
@@ -90,7 +91,8 @@ const styles = theme => ({
     width: theme.spacing.unit * 7 + 1,
     [theme.breakpoints.up("sm")]: {
       width: theme.spacing.unit * 9 + 1
-    }
+    },
+    backgroundColor: theme.palette.primary.main
   },
   toolbar: {
     display: "flex",
@@ -115,7 +117,11 @@ const styles = theme => ({
   },
   fab: {
     zIndex: theme.zIndex.drawer + 2,
-    backgroundColor: theme.palette.primary.dark
+    backgroundColor: theme.palette.primary.dark,
+    boxShadow: "0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23)"
+  },
+  fabExtendedIcon: {
+    marginRight: theme.spacing.unit
   },
   newNote: {
     position: "fixed",
@@ -137,7 +143,9 @@ const noteCategories = ["Favorite Notes", "All Notes"];
 
 function WorkspacePage(props) {
   const { classes, theme, drawerOpen, fabClicked, newNote } = props;
-  console.log(theme);
+  const colorWhite = {
+    color: theme.palette.primary.contrastText
+  };
   return (
     <div className={classes.page}>
       <div className={classes.root}>
@@ -179,8 +187,10 @@ function WorkspacePage(props) {
           open={drawerOpen}
         >
           <div className={classes.toolbar}>
-            <Typography variant="h5">puffnote</Typography>
-            <IconButton onClick={() => props.hideDrawer()}>
+            <Typography variant="h5" style={colorWhite}>
+              puffnote
+            </Typography>
+            <IconButton style={colorWhite} onClick={() => props.hideDrawer()}>
               {theme.direction === "rtl" ? (
                 <ChevronRightIcon />
               ) : (
@@ -192,10 +202,16 @@ function WorkspacePage(props) {
           <List>
             {noteCategories.map((text, index) => (
               <ListItem button key={text}>
-                <ListItemIcon>
+                <ListItemIcon style={colorWhite}>
                   {index % 2 === 0 ? <FavoriteIcon /> : <AppsIcon />}
                 </ListItemIcon>
-                <ListItemText primary={text} />
+                <ListItemText
+                  primary={
+                    <Typography variant="body1" style={colorWhite}>
+                      {text}
+                    </Typography>
+                  }
+                />
               </ListItem>
             ))}
           </List>
@@ -203,19 +219,31 @@ function WorkspacePage(props) {
           <List>
             {users.map(text => (
               <ListItem button key={text}>
-                <ListItemIcon>
+                <ListItemIcon style={colorWhite}>
                   <PersonIcon />
                 </ListItemIcon>
-                <ListItemText primary={text} />
+                <ListItemText
+                  primary={
+                    <Typography variant="body1" style={colorWhite}>
+                      {text}
+                    </Typography>
+                  }
+                />
               </ListItem>
             ))}
           </List>
           <Divider />
           <ListItem button key="Settings">
-            <ListItemIcon>
+            <ListItemIcon style={colorWhite}>
               <SettingsIcon />
             </ListItemIcon>
-            <ListItemText primary="Settings" />
+            <ListItemText
+              primary={
+                <Typography variant="body1" style={colorWhite}>
+                  Settings
+                </Typography>
+              }
+            />
           </ListItem>
         </Drawer>
         <main className={classes.content}>
@@ -226,11 +254,13 @@ function WorkspacePage(props) {
       <div className={classes.fabDiv}>
         <Fab
           color="primary"
+          variant="extended"
           aria-label="Add"
           className={classes.fab}
           onClick={() => props.newNote()}
         >
-          <AddIcon />
+          <AddIcon className={classes.fabExtendedIcon} />
+          Add
         </Fab>
       </div>
       <NoteDialog />

--- a/src/components/WorkspacePage/WorkspacePage.jsx
+++ b/src/components/WorkspacePage/WorkspacePage.jsx
@@ -15,11 +15,9 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  ExpansionPanel,
-  ExpansionPanelSummary,
-  ExpansionPanelDetails,
-  ExpansionPanelActions,
-  Button
+  Fab,
+  Paper,
+  Slide
 } from "@material-ui/core";
 import MenuIcon from "@material-ui/icons/Menu";
 import ChevronLeftIcon from "@material-ui/icons/ChevronLeft";
@@ -28,15 +26,23 @@ import FavoriteIcon from "@material-ui/icons/Favorite";
 import PersonIcon from "@material-ui/icons/Person";
 import SettingsIcon from "@material-ui/icons/Settings";
 import AppsIcon from "@material-ui/icons/Apps";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import AddIcon from "@material-ui/icons/Add";
 import WorkspacePageContent from "../WorkspacePageContent/WorkspacePageContent";
-import { showDrawer, hideDrawer } from "../../actions/workspacePage";
+import {
+  showDrawer,
+  hideDrawer,
+  fabChecked,
+  fabHidden
+} from "../../actions/workspacePage";
 import NoteForm from "../NoteForm/NoteForm";
 import NoteDialog from "../NoteDialog/NoteDialog";
 
 const drawerWidth = 240;
 
 const styles = theme => ({
+  page: {
+    height: "-webkit-fill-available"
+  },
   root: {
     display: "flex"
   },
@@ -97,23 +103,42 @@ const styles = theme => ({
     flexDirection: "column",
     flexGrow: 1
   },
-  newNoteExpansion: {
-    alignSelf: "center",
-    top: theme.spacing.unit * 2,
-    bottom: theme.spacing.unit * 2,
-    width: "50%",
-    zIndex: 1,
-    backgroundColor: theme.palette.background.paper
-  }
+  fabDiv: {
+    position: "fixed",
+    display: "flex",
+    justifyContent: "center",
+    margin: "auto",
+    width: "100%",
+    bottom: theme.spacing.unit * 4,
+    alignItems: "center"
+  },
+  fab: {
+    zIndex: theme.zIndex.drawer + 2,
+    backgroundColor: theme.palette.primary.dark
+  },
+  newNote: {
+    position: "fixed",
+    top: "auto",
+    left: "auto",
+    right: "12.5%",
+    bottom: "12.5%",
+    width: "75%",
+    height: "75%",
+    boxShadow: "0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23)",
+    zIndex: theme.zIndex.drawer + 2,
+    padding: theme.spacing.unit * 2
+  },
+  newNotePaper: {}
 });
 
 const users = ["Alex", "Price", "John", "Jim"];
 const noteCategories = ["Favorite Notes", "All Notes"];
 
 function WorkspacePage(props) {
-  const { classes, theme, drawerOpen } = props;
+  const { classes, theme, drawerOpen, fabClicked } = props;
+  console.log(theme);
   return (
-    <div>
+    <div className={classes.page}>
       <div className={classes.root}>
         <CssBaseline />
         <AppBar
@@ -194,30 +219,32 @@ function WorkspacePage(props) {
         </Drawer>
         <main className={classes.content}>
           <div className={classes.toolbar} />
-          <ExpansionPanel className={classes.newNoteExpansion} boxshadow={3}>
-            <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-              <div className={classes.column}>
-                <Typography variant="subtitle2" color="inherit">
-                  New Note
-                </Typography>
-              </div>
-            </ExpansionPanelSummary>
-            <ExpansionPanelDetails>
-              <NoteForm />
-            </ExpansionPanelDetails>
-            <Divider />
-            <ExpansionPanelActions>
-              <Button variant="contained" size="small" color="secondary">
-                Cancel
-              </Button>
-              <Button variant="contained" size="small" color="primary">
-                Save
-              </Button>
-            </ExpansionPanelActions>
-          </ExpansionPanel>
           <WorkspacePageContent notes />
         </main>
       </div>
+      <div className={classes.fabDiv}>
+        <Fab
+          color="primary"
+          aria-label="Add"
+          className={classes.fab}
+          onClick={() => props.fabChecked()}
+          onBlur={() => props.fabHidden()}
+          onClose={() => props.fabHidden()}
+        >
+          <AddIcon />
+        </Fab>
+      </div>
+      <Slide
+        direction="up"
+        in={fabClicked}
+        className={classes.newNote}
+        mountOnEnter
+        unmountOnExit
+      >
+        <Paper elevation={4} className={classes.newNotePaper}>
+          <NoteForm />
+        </Paper>
+      </Slide>
       <NoteDialog />
     </div>
   );
@@ -226,18 +253,24 @@ function WorkspacePage(props) {
 WorkspacePage.propTypes = {
   showDrawer: PropTypes.func.isRequired,
   hideDrawer: PropTypes.func.isRequired,
+  fabChecked: PropTypes.func.isRequired,
+  fabHidden: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
   theme: PropTypes.object.isRequired,
-  drawerOpen: PropTypes.bool.isRequired
+  drawerOpen: PropTypes.bool.isRequired,
+  fabClicked: PropTypes.bool.isRequired
 };
 
-const mapStateToProps = ({ workspacePage: { drawerOpen } }) => ({
-  drawerOpen
+const mapStateToProps = ({ workspacePage: { drawerOpen, fabClicked } }) => ({
+  drawerOpen,
+  fabClicked
 });
 
 const mapDispatchToProps = {
   showDrawer,
-  hideDrawer
+  hideDrawer,
+  fabChecked,
+  fabHidden
 };
 
 export default connect(

--- a/src/components/WorkspacePage/WorkspacePage.jsx
+++ b/src/components/WorkspacePage/WorkspacePage.jsx
@@ -36,6 +36,7 @@ import {
 } from "../../actions/workspacePage";
 import NoteForm from "../NoteForm/NoteForm";
 import NoteDialog from "../NoteDialog/NoteDialog";
+import { editNote } from "../../actions/workspaceCard";
 
 const drawerWidth = 240;
 
@@ -135,7 +136,7 @@ const users = ["Alex", "Price", "John", "Jim"];
 const noteCategories = ["Favorite Notes", "All Notes"];
 
 function WorkspacePage(props) {
-  const { classes, theme, drawerOpen, fabClicked } = props;
+  const { classes, theme, drawerOpen, fabClicked, newNote } = props;
   console.log(theme);
   return (
     <div className={classes.page}>
@@ -227,24 +228,11 @@ function WorkspacePage(props) {
           color="primary"
           aria-label="Add"
           className={classes.fab}
-          onClick={() => props.fabChecked()}
-          onBlur={() => props.fabHidden()}
-          onClose={() => props.fabHidden()}
+          onClick={() => props.newNote()}
         >
           <AddIcon />
         </Fab>
       </div>
-      <Slide
-        direction="up"
-        in={fabClicked}
-        className={classes.newNote}
-        mountOnEnter
-        unmountOnExit
-      >
-        <Paper elevation={4} className={classes.newNotePaper}>
-          <NoteForm />
-        </Paper>
-      </Slide>
       <NoteDialog />
     </div>
   );
@@ -255,6 +243,7 @@ WorkspacePage.propTypes = {
   hideDrawer: PropTypes.func.isRequired,
   fabChecked: PropTypes.func.isRequired,
   fabHidden: PropTypes.func.isRequired,
+  newNote: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
   theme: PropTypes.object.isRequired,
   drawerOpen: PropTypes.bool.isRequired,
@@ -270,7 +259,8 @@ const mapDispatchToProps = {
   showDrawer,
   hideDrawer,
   fabChecked,
-  fabHidden
+  fabHidden,
+  newNote: editNote
 };
 
 export default connect(

--- a/src/reducers/noteDialog.js
+++ b/src/reducers/noteDialog.js
@@ -1,7 +1,8 @@
 import {
   SHOW_NOTE_DIALOG,
   HIDE_NOTE_DIALOG,
-  SAVE_NOTE_DIALOG_CONTENT
+  SAVE_NOTE_DIALOG_CONTENT,
+  ADD_NOTE
 } from "../actions/noteDialog";
 
 export default (state = {}, action) => {
@@ -13,6 +14,11 @@ export default (state = {}, action) => {
       };
     case HIDE_NOTE_DIALOG:
     case SAVE_NOTE_DIALOG_CONTENT:
+      return {
+        ...state,
+        open: false
+      };
+    case ADD_NOTE:
       return {
         ...state,
         open: false

--- a/src/reducers/noteForm.js
+++ b/src/reducers/noteForm.js
@@ -1,7 +1,8 @@
 import { EDIT_NOTE } from "../actions/workspaceCard";
 import {
   HIDE_NOTE_DIALOG,
-  SAVE_NOTE_DIALOG_CONTENT
+  SAVE_NOTE_DIALOG_CONTENT,
+  ADD_NOTE
 } from "../actions/noteDialog";
 import { SET_TITLE, SET_CONTENT } from "../actions/noteForm";
 
@@ -13,6 +14,8 @@ export default (state = initialState, action) => {
       return action.payload;
     case HIDE_NOTE_DIALOG:
     case SAVE_NOTE_DIALOG_CONTENT:
+      return initialState;
+    case ADD_NOTE:
       return initialState;
     case SET_TITLE:
       return {

--- a/src/reducers/workspacePage.js
+++ b/src/reducers/workspacePage.js
@@ -1,7 +1,13 @@
-import { SHOW_DRAWER, HIDE_DRAWER } from "../actions/workspacePage";
+import {
+  SHOW_DRAWER,
+  HIDE_DRAWER,
+  FAB_CHECKED,
+  FAB_HIDDEN
+} from "../actions/workspacePage";
 
 const initialState = {
-  drawerOpen: false
+  drawerOpen: false,
+  fabClicked: false
 };
 
 export default (state = initialState, action) => {
@@ -15,6 +21,16 @@ export default (state = initialState, action) => {
       return {
         ...state,
         drawerOpen: false
+      };
+    case FAB_CHECKED:
+      return {
+        ...state,
+        fabClicked: !state.fabClicked
+      };
+    case FAB_HIDDEN:
+      return {
+        ...state,
+        fabClicked: false
       };
     default:
       return state;

--- a/src/reducers/workspacePage.js
+++ b/src/reducers/workspacePage.js
@@ -2,12 +2,17 @@ import {
   SHOW_DRAWER,
   HIDE_DRAWER,
   FAB_CHECKED,
-  FAB_HIDDEN
+  FAB_HIDDEN,
+  SHOW_CREATE_USER_DIALOG,
+  HIDE_CREATE_USER_DIALOG
 } from "../actions/workspacePage";
 
 const initialState = {
   drawerOpen: false,
-  fabClicked: false
+  fabClicked: false,
+  showCreateUserDialog: false,
+  // TODO: Change this along with service integration
+  roomId: "abcdef"
 };
 
 export default (state = initialState, action) => {
@@ -31,6 +36,16 @@ export default (state = initialState, action) => {
       return {
         ...state,
         fabClicked: false
+      };
+    case SHOW_CREATE_USER_DIALOG:
+      return {
+        ...state,
+        showCreateUserDialog: true
+      };
+    case HIDE_CREATE_USER_DIALOG:
+      return {
+        ...state,
+        showCreateUserDialog: false
       };
     default:
       return state;

--- a/src/reducers/workspacePageContent.js
+++ b/src/reducers/workspacePageContent.js
@@ -1,5 +1,5 @@
 import { SET_NOTES } from "../actions/workspacePageContent";
-import { SAVE_NOTE_DIALOG_CONTENT } from "../actions/noteDialog";
+import { SAVE_NOTE_DIALOG_CONTENT, ADD_NOTE } from "../actions/noteDialog";
 
 const initialState = {
   // TODO: Remove these default values and load an empty notes array
@@ -91,6 +91,20 @@ export default (state = initialState, action) => {
         notes: state.notes.map(note =>
           note.uuid === action.payload.uuid ? action.payload : note
         )
+      };
+    }
+    case ADD_NOTE: {
+      // TODO: Refactor required. Temporarily adding note. Values hardcoded.
+      // TODO: Refactor required, dont add to state, send title and content and user uuid to endpoint
+      const note = {
+        title: action.payload.title ? action.payload.title : "Hello",
+        content: action.payload.content ? action.payload.content : "ABCDEF",
+        uuid: Math.random() * 10,
+        avatar: "K"
+      };
+      return {
+        ...state,
+        notes: [...state.notes, note]
       };
     }
     default:

--- a/src/reducers/workspacePageContent.js
+++ b/src/reducers/workspacePageContent.js
@@ -17,6 +17,62 @@ const initialState = {
       title: "New Note2",
       content:
         "This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text"
+    },
+    {
+      uuid: "3",
+      avatar: "R",
+      title: "New Note1",
+      content:
+        "This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text"
+    },
+    {
+      uuid: "4",
+      avatar: "R",
+      title: "New Note2",
+      content:
+        "This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text"
+    },
+    {
+      uuid: "5",
+      avatar: "R",
+      title: "New Note1",
+      content:
+        "This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text"
+    },
+    {
+      uuid: "6",
+      avatar: "R",
+      title: "New Note2",
+      content:
+        "This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text"
+    },
+    {
+      uuid: "7",
+      avatar: "R",
+      title: "New Note1",
+      content:
+        "This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text"
+    },
+    {
+      uuid: "8",
+      avatar: "R",
+      title: "New Note2",
+      content:
+        "This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text"
+    },
+    {
+      uuid: "9",
+      avatar: "R",
+      title: "New Note1",
+      content:
+        "This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text"
+    },
+    {
+      uuid: "10",
+      avatar: "R",
+      title: "New Note2",
+      content:
+        "This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text. This is random text"
     }
   ]
 };

--- a/src/ui/theme/index.js
+++ b/src/ui/theme/index.js
@@ -2,7 +2,7 @@ import { createMuiTheme } from "@material-ui/core/styles";
 
 const palette = {
   primary: { main: "#3c3c3c", contrastText: "#ffffff" },
-  secondary: { main: "#cc461f" }
+  secondary: { main: "#cc461f", contrastText: "#ffffff" }
 };
 const themeName = "Mine Shaft Orange Roughy Monarch Butterfly";
 const typography = { useNextVariants: true }; // switch to typography v2

--- a/yarn.lock
+++ b/yarn.lock
@@ -9070,6 +9070,19 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qr.js@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
+  integrity sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8=
+
+qrcode.react@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-0.9.3.tgz#91de1287912bdc5ccfb3b091737b828d6ced60c5"
+  integrity sha512-gGd30Ez7cmrKxyN2M3nueaNLk/f9J7NDRgaD5fVgxGpPLsYGWMn9UQ+XnDpv95cfszTQTdaf4QGLNMf3xU0hmw==
+  dependencies:
+    prop-types "^15.6.0"
+    qr.js "0.0.0"
+
 qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"


### PR DESCRIPTION
### What has been changed?
- Expansion Panel replaced with extended FAB
- Slide transitions enforced across dialogs
- New note can be added from FAB overlay
- Other styling and layout changes


### How was it tested?
App running locally - FAB works as expected, note saved as expected to local state